### PR TITLE
Show dependency updates in security section instead of enhancements

### DIFF
--- a/.github/workflows/release-pull-request.yaml
+++ b/.github/workflows/release-pull-request.yaml
@@ -49,8 +49,9 @@ jobs:
           futureRelease: ${{ steps.get-next-version.outputs.next-version }}
           breakingLabels: backwards-incompatible,breaking
           removedLabels: removal
-          enhancementLabels: feature,enhancement,improvement,infrastructure
+          enhancementLabels: feature,enhancement,improvement
           bugLabels: bug
+          securityLabel: infrastructure
           excludeLabels: skip-changelog
           output: CHANGELOG.md
           usernamesAsGithubLogins: true


### PR DESCRIPTION
Makes the changelog more readable and important changes don't hide between all the dependency update clutter